### PR TITLE
fix: resolve Telegram notification bugs and add approval buttons

### DIFF
--- a/claude-hook-notify.js
+++ b/claude-hook-notify.js
@@ -36,6 +36,46 @@ const TelegramChannel = require('./src/channels/telegram/telegram');
 const DesktopChannel = require('./src/channels/local/desktop');
 const EmailChannel = require('./src/channels/email/smtp');
 
+/**
+ * Read hook data from stdin (Claude Code passes JSON via stdin to hooks)
+ */
+function readStdin() {
+    return new Promise((resolve) => {
+        if (process.stdin.isTTY) {
+            resolve(null);
+            return;
+        }
+
+        let data = '';
+        let resolved = false;
+
+        const done = (value) => {
+            if (resolved) return;
+            resolved = true;
+            clearTimeout(timer);
+            process.stdin.removeListener('data', onData);
+            process.stdin.removeListener('end', onEnd);
+            resolve(value);
+        };
+
+        const onData = (chunk) => { data += chunk; };
+        const onEnd = () => {
+            if (!data.trim()) { done(null); return; }
+            try {
+                done(JSON.parse(data));
+            } catch (e) {
+                done(null);
+            }
+        };
+
+        process.stdin.setEncoding('utf8');
+        process.stdin.on('data', onData);
+        process.stdin.on('end', onEnd);
+
+        const timer = setTimeout(() => done(null), 1000);
+    });
+}
+
 async function sendHookNotification() {
     try {
         console.log('🔔 Claude Hook: Sending notifications...');
@@ -93,12 +133,12 @@ async function sendHookNotification() {
         // Get current working directory and tmux session
         const currentDir = process.cwd();
         const projectName = path.basename(currentDir);
-        
+
         // Try to get current tmux session
         let tmuxSession = process.env.TMUX_SESSION || 'claude-real';
         try {
             const { execSync } = require('child_process');
-            const sessionOutput = execSync('tmux display-message -p "#S"', { 
+            const sessionOutput = execSync('tmux display-message -p "#S"', {
                 encoding: 'utf8',
                 stdio: ['ignore', 'pipe', 'ignore']
             }).trim();
@@ -108,16 +148,52 @@ async function sendHookNotification() {
         } catch (error) {
             // Not in tmux or tmux not available, use default
         }
-        
+
+        // Read hook data from stdin — Claude Code hooks pass JSON with result/transcript
+        const hookData = await readStdin();
+
+        let userQuestion = '';
+        let claudeResponse = '';
+
+        if (hookData) {
+            // Extract from hook result or transcript_summary
+            if (hookData.result) {
+                claudeResponse = typeof hookData.result === 'string'
+                    ? hookData.result
+                    : JSON.stringify(hookData.result);
+            }
+            if (hookData.transcript_summary) {
+                claudeResponse = claudeResponse || hookData.transcript_summary;
+            }
+            if (hookData.input) {
+                userQuestion = typeof hookData.input === 'string'
+                    ? hookData.input
+                    : JSON.stringify(hookData.input);
+            }
+            if (hookData.session_id) {
+                tmuxSession = hookData.session_id;
+            }
+        }
+
         // Create notification
         const notification = {
             type: notificationType,
             title: `Claude ${notificationType === 'completed' ? 'Task Completed' : 'Waiting for Input'}`,
-            message: `Claude has ${notificationType === 'completed' ? 'completed a task' : 'is waiting for input'}`,
+            message: notificationType === 'completed'
+                ? 'Claude has completed a task'
+                : 'Claude is waiting for input',
             project: projectName
-            // Don't set metadata here - let TelegramChannel extract real conversation content
         };
-        
+
+        // Set metadata from stdin data if available; otherwise let TelegramChannel try tmux capture
+        if (userQuestion || claudeResponse) {
+            notification.metadata = {
+                userQuestion: userQuestion || 'Recent command',
+                claudeResponse: claudeResponse || 'Task completed',
+                tmuxSession: tmuxSession
+            };
+        }
+
         console.log(`📱 Sending ${notificationType} notification for project: ${projectName}`);
         console.log(`🖥️ Tmux session: ${tmuxSession}`);
         

--- a/src/channels/telegram/telegram.js
+++ b/src/channels/telegram/telegram.js
@@ -109,7 +109,7 @@ class TelegramChannel extends NotificationChannel {
         // Generate session ID and Token
         const sessionId = uuidv4();
         const token = this._generateToken();
-        
+
         // Get current tmux session and conversation content
         const tmuxSession = this._getCurrentTmuxSession();
         if (tmuxSession && !notification.metadata) {
@@ -120,53 +120,68 @@ class TelegramChannel extends NotificationChannel {
                 tmuxSession: tmuxSession
             };
         }
-        
+
         // Create session record
         await this._createSession(sessionId, notification, token);
 
         // Generate Telegram message
         const messageText = this._generateTelegramMessage(notification, sessionId, token);
-        
+
         // Determine recipient (chat or group)
         const chatId = this.config.groupId || this.config.chatId;
-        const isGroupChat = !!this.config.groupId;
-        
-        // Create buttons using callback_data instead of inline query
-        // This avoids the automatic @bot_name addition
-        const buttons = [
-            [
-                {
-                    text: '📝 Personal Chat',
-                    callback_data: `personal:${token}`
-                },
-                {
-                    text: '👥 Group Chat', 
-                    callback_data: `group:${token}`
-                }
-            ]
-        ];
-        
-        const requestData = {
-            chat_id: chatId,
-            text: messageText,
-            parse_mode: 'Markdown',
-            reply_markup: {
-                inline_keyboard: buttons
-            }
-        };
+
+        // Detect if Claude is asking for approval and choose appropriate buttons
+        const claudeResponse = notification.metadata?.claudeResponse || '';
+        const isApproval = this._detectApprovalRequest(claudeResponse);
+
+        let buttons;
+        if (isApproval) {
+            buttons = this._generateApprovalButtons(token);
+        } else {
+            buttons = [
+                [
+                    { text: '📝 Personal Chat', callback_data: `personal:${token}` },
+                    { text: '👥 Group Chat', callback_data: `group:${token}` }
+                ]
+            ];
+        }
+
+        // Split long messages
+        const messageParts = this._splitMessage(messageText);
 
         try {
-            const response = await axios.post(
-                `${this.apiBaseUrl}/bot${this.config.botToken}/sendMessage`,
-                requestData,
-                this._getNetworkOptions()
-            );
+            // Send all parts; only the last part gets buttons
+            for (let i = 0; i < messageParts.length; i++) {
+                const isLastPart = i === messageParts.length - 1;
+                const requestData = {
+                    chat_id: chatId,
+                    text: messageParts[i],
+                    parse_mode: 'Markdown',
+                    ...(isLastPart ? { reply_markup: { inline_keyboard: buttons } } : {})
+                };
+
+                try {
+                    await axios.post(
+                        `${this.apiBaseUrl}/bot${this.config.botToken}/sendMessage`,
+                        requestData,
+                        this._getNetworkOptions()
+                    );
+                } catch (markdownErr) {
+                    // Markdown parse failed — retry as plain text
+                    const fallbackData = { ...requestData };
+                    delete fallbackData.parse_mode;
+                    await axios.post(
+                        `${this.apiBaseUrl}/bot${this.config.botToken}/sendMessage`,
+                        fallbackData,
+                        this._getNetworkOptions()
+                    );
+                }
+            }
 
             this.logger.info(`Telegram message sent successfully, Session: ${sessionId}`);
             return true;
         } catch (error) {
             this.logger.error('Failed to send Telegram message:', error.response?.data || error.message);
-            // Clean up failed session
             await this._removeSession(sessionId);
             return false;
         }
@@ -176,34 +191,126 @@ class TelegramChannel extends NotificationChannel {
         const type = notification.type;
         const emoji = type === 'completed' ? '✅' : '⏳';
         const status = type === 'completed' ? 'Completed' : 'Waiting for Input';
-        
+
         let messageText = `${emoji} *Claude Task ${status}*\n`;
-        messageText += `*Project:* ${notification.project}\n`;
+        messageText += `*Project:* ${this._escapeTelegramMarkdown(notification.project)}\n`;
         messageText += `*Session Token:* \`${token}\`\n\n`;
-        
+
         if (notification.metadata) {
             if (notification.metadata.userQuestion) {
-                messageText += `📝 *Your Question:*\n${notification.metadata.userQuestion.substring(0, 200)}`;
-                if (notification.metadata.userQuestion.length > 200) {
-                    messageText += '...';
-                }
+                const q = this._sanitizeTerminalOutput(notification.metadata.userQuestion);
+                const escaped = this._escapeTelegramMarkdown(q.substring(0, 200));
+                messageText += `📝 *Your Question:*\n${escaped}`;
+                if (q.length > 200) messageText += '...';
                 messageText += '\n\n';
             }
-            
+
             if (notification.metadata.claudeResponse) {
-                messageText += `🤖 *Claude Response:*\n${notification.metadata.claudeResponse.substring(0, 300)}`;
-                if (notification.metadata.claudeResponse.length > 300) {
-                    messageText += '...';
-                }
+                const r = this._sanitizeTerminalOutput(notification.metadata.claudeResponse);
+                const escaped = this._escapeTelegramMarkdown(r.substring(0, 300));
+                messageText += `🤖 *Claude Response:*\n${escaped}`;
+                if (r.length > 300) messageText += '...';
                 messageText += '\n\n';
             }
         }
-        
+
         messageText += `💬 *To send a new command:*\n`;
         messageText += `Reply with: \`/cmd ${token} <your command>\`\n`;
         messageText += `Example: \`/cmd ${token} Please analyze this code\``;
 
         return messageText;
+    }
+
+    /**
+     * Escape special characters for Telegram Markdown (v1)
+     */
+    _escapeTelegramMarkdown(text) {
+        if (!text) return '';
+        return text
+            .replace(/_/g, '\\_')
+            .replace(/\*/g, '\\*')
+            .replace(/\[/g, '\\[')
+            .replace(/]/g, '\\]')
+            .replace(/`/g, '\\`');
+    }
+
+    /**
+     * Strip ANSI escape codes and box-drawing characters from terminal output
+     */
+    _sanitizeTerminalOutput(text) {
+        if (!text) return '';
+        return text
+            // Strip ANSI CSI sequences (including ? for cursor/mode codes)
+            .replace(/\x1B\[[0-9;?]*[a-zA-Z]/g, '')
+            // Strip OSC sequences (BEL or ST terminated)
+            .replace(/\x1B\].*?(?:\x07|\x1B\\)/g, '')
+            // Strip box-drawing characters
+            .replace(/[╭╮╰╯│─┬┴┼├┤┌┐└┘]/g, '')
+            .trim();
+    }
+
+    /**
+     * Split long messages to stay under Telegram's 4096 char limit
+     */
+    _splitMessage(text, maxLen = 4000) {
+        if (text.length <= maxLen) return [text];
+
+        const parts = [];
+        let remaining = text;
+        let safety = 0;
+        while (remaining.length > 0 && safety++ < 20) {
+            if (remaining.length <= maxLen) {
+                parts.push(remaining);
+                break;
+            }
+            // Find a good split point (newline near the limit)
+            let splitAt = remaining.lastIndexOf('\n', maxLen);
+            if (splitAt < maxLen * 0.5) splitAt = maxLen;
+            parts.push(remaining.substring(0, splitAt));
+            remaining = remaining.substring(splitAt).trimStart();
+        }
+
+        // Add part labels if split into multiple
+        if (parts.length > 1) {
+            return parts.map((p, i) => `[${i + 1}/${parts.length}]\n${p}`);
+        }
+        return parts;
+    }
+
+    /**
+     * Detect if Claude's response is asking for user approval/permission
+     */
+    _detectApprovalRequest(text) {
+        if (!text) return false;
+        const patterns = [
+            /Do you want to\b/i,
+            /\bShould I\b/i,
+            /Would you like me to\b/i,
+            /\bAllow this\b/i,
+            /\bApprove this\b/i,
+            /Do you approve\b/i,
+            /\bMay I\b/i,
+            /\bCan I proceed\b/i,
+            /\bShall I\b/i,
+            /\(y\/n\)/i,
+            /\[Y\/n\]/i,
+            /\[yes\/no\]/i,
+            /Press Enter to confirm/i,
+            /Do you want to proceed/i
+        ];
+        return patterns.some((p) => p.test(text));
+    }
+
+    /**
+     * Generate inline keyboard buttons for approval actions
+     */
+    _generateApprovalButtons(token) {
+        return [
+            [
+                { text: '✅ Yes', callback_data: `approve:${token}:yes` },
+                { text: '❌ No', callback_data: `approve:${token}:no` }
+            ]
+        ];
     }
 
     async _createSession(sessionId, notification, token) {

--- a/src/channels/telegram/webhook.js
+++ b/src/channels/telegram/webhook.js
@@ -159,30 +159,76 @@ class TelegramWebhookHandler {
 
     async _handleCallbackQuery(callbackQuery) {
         const chatId = callbackQuery.message.chat.id;
+        const userId = callbackQuery.from.id;
         const data = callbackQuery.data;
-        
+
+        // Verify authorization before processing any callback
+        if (!this._isAuthorized(userId, chatId)) {
+            await this._answerCallbackQuery(callbackQuery.id, 'Not authorized');
+            return;
+        }
+
         // Answer callback query to remove loading state
         await this._answerCallbackQuery(callbackQuery.id);
-        
-        if (data.startsWith('personal:')) {
+
+        if (data.startsWith('approve:')) {
+            await this._handleApprovalCallback(chatId, data);
+        } else if (data.startsWith('personal:')) {
             const token = data.split(':')[1];
-            // Send personal chat command format
             await this._sendMessage(chatId,
                 `📝 *Personal Chat Command Format:*\n\n\`/cmd ${token} <your command>\`\n\n*Example:*\n\`/cmd ${token} please analyze this code\`\n\n💡 *Copy and paste the format above, then add your command!*`,
                 { parse_mode: 'Markdown' });
         } else if (data.startsWith('group:')) {
             const token = data.split(':')[1];
-            // Send group chat command format with @bot_name
             const botUsername = await this._getBotUsername();
             await this._sendMessage(chatId,
                 `👥 *Group Chat Command Format:*\n\n\`@${botUsername} /cmd ${token} <your command>\`\n\n*Example:*\n\`@${botUsername} /cmd ${token} please analyze this code\`\n\n💡 *Copy and paste the format above, then add your command!*`,
                 { parse_mode: 'Markdown' });
         } else if (data.startsWith('session:')) {
             const token = data.split(':')[1];
-            // For backward compatibility - send help message for old callback buttons
             await this._sendMessage(chatId,
                 `📝 *How to send a command:*\n\nType:\n\`/cmd ${token} <your command>\`\n\nExample:\n\`/cmd ${token} please analyze this code\`\n\n💡 *Tip:* New notifications have a button that auto-fills the command for you!`,
                 { parse_mode: 'Markdown' });
+        }
+    }
+
+    async _handleApprovalCallback(chatId, data) {
+        // Format: approve:TOKEN:action
+        const parts = data.split(':');
+        if (parts.length < 3) {
+            await this._sendMessage(chatId, '❌ Invalid approval data.');
+            return;
+        }
+
+        const token = parts[1];
+        const action = parts[2];
+
+        const session = await this._findSessionByToken(token);
+        if (!session) {
+            await this._sendMessage(chatId, '❌ Invalid or expired token.');
+            return;
+        }
+
+        const tmuxSession = session.tmuxSession || 'default';
+        const actionMap = { yes: 'y', no: 'n' };
+        const command = actionMap[action];
+        if (!command) {
+            await this._sendMessage(chatId, '❌ Unknown approval action.');
+            return;
+        }
+
+        try {
+            await this.injector.injectCommand(command, tmuxSession);
+
+            const labels = { yes: '✅ Approved', no: '❌ Rejected' };
+            await this._sendMessage(chatId,
+                `${labels[action]} — response sent to session *${tmuxSession}*`,
+                { parse_mode: 'Markdown' });
+
+            this.logger.info(`Approval callback — Token: ${token}, Action: ${action}, Session: ${tmuxSession}`);
+        } catch (error) {
+            this.logger.error('Approval injection failed:', error.message);
+            await this._sendMessage(chatId, `❌ Failed to send approval: ${error.message}`);
         }
     }
 

--- a/start-telegram-webhook.js
+++ b/start-telegram-webhook.js
@@ -17,6 +17,9 @@ if (fs.existsSync(envPath)) {
     dotenv.config({ path: envPath });
 }
 
+// Prevent nested Claude Code session detection when webhook is started from within a Claude session
+delete process.env.CLAUDECODE;
+
 const logger = new Logger('Telegram-Webhook-Server');
 
 // Load configuration


### PR DESCRIPTION
## Summary

- **CLAUDECODE env var leak**: Delete `process.env.CLAUDECODE` after loading `.env` in webhook server, preventing nested Claude Code session detection when started from within a Claude session.
- **Notification content empty**: Read hook data from stdin (JSON passed by Claude Code hooks) instead of relying on `tmux capture-pane`, which fails because Claude Code's TUI clears the screen after completion. Falls back to tmux capture if stdin has no data.
- **Telegram Markdown parse errors (400 Bad Request)**: Escape Markdown V1 special characters (`_`, `*`, `` ` ``, `[`, `]`) in user-generated content, sanitize ANSI escape codes and box-drawing characters from terminal output, and retry as plain text if Markdown send still fails.
- **Approval buttons for tmux mode**: When Claude's response is detected as a permission prompt (e.g. "Do you want to...", "(y/n)"), show Yes/No inline buttons instead of Personal/Group chat buttons. Clicking a button injects `y` or `n` into the tmux session. Added authorization check on all callback queries.
- **Message splitting**: Split messages exceeding Telegram's 4096 char limit into labeled parts `[1/N]`.

## Test plan

- [ ] Start webhook server via `node start-telegram-webhook.js` — verify no CLAUDECODE env var warnings
- [ ] Trigger a Claude Code hook notification — verify Telegram message shows actual question/response content (not "No user input" / "No Claude response")
- [ ] Send a notification containing Markdown special chars (`_`, `*`, backticks) — verify no 400 Bad Request error
- [ ] When Claude asks for permission in tmux, verify Yes/No approval buttons appear in Telegram
- [ ] Click an approval button — verify the response is injected into the tmux session
- [ ] Verify unauthorized users cannot click approval buttons in group chats